### PR TITLE
docs: harmoniser le nommage des assets de release

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,18 @@ Configure Claude Code (`.mcp.json`):
 
 | Artifact | Platform | Architecture |
 |----------|----------|-------------|
-| `Alter-1.13.7-macOS-Notarized.dmg` | macOS | Universal |
-| `alter-cli-macos-arm64.tar.gz` | macOS | Apple Silicon |
-| `alter-cli-macos-x64.tar.gz` | macOS | Intel |
-| `alter-cli-linux-arm64.tar.gz` | Linux | ARM64 |
-| `alter-cli-linux-x64.tar.gz` | Linux | x64 |
-| `alter-mcp-macos-arm64.tar.gz` | macOS | Apple Silicon |
-| `alter-mcp-macos-x64.tar.gz` | macOS | Intel |
-| `alter-mcp-linux-arm64.tar.gz` | Linux | ARM64 |
-| `alter-mcp-linux-x64.tar.gz` | Linux | x64 |
+| `alter-desktop-1.13.7-macos-universal-notarized.dmg` | macOS | Universal |
+| `alter-desktop-1.13.7-windows-x64.zip` | Windows | x64 |
+| `alter-cli-1.13.7-macos-arm64.tar.gz` | macOS | Apple Silicon |
+| `alter-cli-1.13.7-macos-x64.tar.gz` | macOS | Intel |
+| `alter-cli-1.13.7-linux-arm64.tar.gz` | Linux | ARM64 |
+| `alter-cli-1.13.7-linux-x64.tar.gz` | Linux | x64 |
+| `alter-cli-1.13.7-windows-x64.exe` | Windows | x64 |
+| `alter-mcp-1.13.7-macos-arm64.tar.gz` | macOS | Apple Silicon |
+| `alter-mcp-1.13.7-macos-x64.tar.gz` | macOS | Intel |
+| `alter-mcp-1.13.7-linux-arm64.tar.gz` | Linux | ARM64 |
+| `alter-mcp-1.13.7-linux-x64.tar.gz` | Linux | x64 |
+| `alter-mcp-1.13.7-windows-x64.exe` | Windows | x64 |
 
 All artifacts are available on the [Releases page](https://github.com/VISIALIS/homebrew-alter/releases).
 


### PR DESCRIPTION
## Contexte

Les noms d'assets publiés sur les releases du tap étaient asymétriques entre les produits :

| Produit | Format actuel | Casse | Version |
|---|---|---|---|
| Desktop macOS | `Alter-1.13.7-macOS-Notarized.dmg` | `Alter` / `macOS` | oui |
| Desktop Windows | `Alter-1.13.7-windows.zip` | `Alter` / `windows` | oui, sans arch |
| CLI/MCP | `alter-cli-macos-arm64.tar.gz` | tout minuscule | **non** |

Trois divergences : casse mixte, arch parfois implicite, version absente côté CLI/MCP.

## Convention unifiée

Pattern unique : `alter-{produit}-{version}-{os}-{arch}[-suffix].{ext}`

| Avant | Après |
|---|---|
| `Alter-1.13.7-macOS-Notarized.dmg` | `alter-desktop-1.13.7-macos-universal-notarized.dmg` |
| `Alter-1.13.7-windows.zip` | `alter-desktop-1.13.7-windows-x64.zip` |
| `alter-1.13.7-linux.tar.gz` | `alter-desktop-1.13.7-linux-x64.tar.gz` |
| `alter-cli-macos-arm64.tar.gz` | `alter-cli-1.13.7-macos-arm64.tar.gz` |
| `alter-cli-windows-x64.exe` | `alter-cli-1.13.7-windows-x64.exe` |
| (idem mcp) | |

## Impact utilisateur

- **`brew install`** : aucun changement de commande (cask `alter`, formulas `alter-cli` / `alter-mcp` inchangés).
- **Téléchargements directs** : URLs changent à partir de v1.13.8. v1.13.7 et antérieures conservent l'ancien nommage.

## Coordination

À merger **après** la release v1.13.8 de [phoenix_0](https://github.com/VISIALIS/phoenix_0) qui produit les artefacts sous les nouveaux noms. Le pipeline CD régénère ensuite Casks/alter.rb, Formula/alter-{cli,mcp}.rb et patche le README à chaque release.

## Test plan

- [ ] Release v1.13.8 publiée sur phoenix_0 avec nouveau nommage
- [ ] `brew install --cask alter` télécharge `alter-desktop-1.13.8-macos-universal-notarized.dmg`
- [ ] `brew install alter-cli` télécharge `alter-cli-1.13.8-macos-{arm64,x64}.tar.gz` selon l'arch
- [ ] Le perl regex de patch du README dans le CD remplace bien la version à chaque release

🤖 Generated with [Claude Code](https://claude.com/claude-code)